### PR TITLE
Update ethereum provider API

### DIFF
--- a/bridge/bsc.html
+++ b/bridge/bsc.html
@@ -734,8 +734,8 @@
         } else {
             let myEthAddress;
             try {
-                const accounts = (await ethereum.send('eth_requestAccounts')).result;
-                myEthAddress = accounts[0]
+                const accounts = await ethereum.request({method: 'eth_requestAccounts'});
+                myEthAddress = accounts[0];
                 console.log('address is', myEthAddress);
             } catch (error) {
                 console.log(error);
@@ -753,7 +753,8 @@
                 console.log('address is', provider.myEthAddress);
             });
 
-            if (ethereum.networkVersion !== ETH_CHAIN_ID.toString()) {
+            const networkVersion = await ethereum.request({ method: 'net_version' });
+            if (networkVersion !== ETH_CHAIN_ID.toString()) {
                 alert('Set chain to ' + (IS_TESTNET ? 'BSC Testnet' : 'BSC') + ' in Metamask');
                 return null;
             }

--- a/bridge/index.html
+++ b/bridge/index.html
@@ -732,7 +732,7 @@
         } else {
             let myEthAddress;
             try {
-                const accounts = (await ethereum.send('eth_requestAccounts')).result;
+                const accounts = await ethereum.request({method: 'eth_requestAccounts'});
                 myEthAddress = accounts[0]
                 console.log('address is', myEthAddress);
             } catch (error) {
@@ -751,7 +751,8 @@
                 console.log('address is', provider.myEthAddress);
             });
 
-            if (ethereum.networkVersion !== ETH_CHAIN_ID.toString()) {
+            const networkVersion = await ethereum.request({ method: 'net_version' });
+            if (networkVersion !== ETH_CHAIN_ID.toString()) {
                 alert('Set chain to ' + (ETH_CHAIN_ID === 3 ? 'Ropsten' : 'Mainnet') + ' in Metamask');
                 return null;
             }


### PR DESCRIPTION
This change will allow to connect modern wallets, including Trust Wallet, Safepal, etc.
The original methods are deprecated a long time ago.

https://docs.metamask.io/guide/ethereum-provider.html#ethereum-send-deprecated

This change will allow for basic wallet connection & bridge usage, but probably further changes are required to convert all the legacy stuff.

Personally I tested the BSC bridge from the SafePal DApp browser + Tonkeeper app - everything worked as smooth as possible!